### PR TITLE
Update version of docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.6
 MAINTAINER Dmitry Matrosov <amidos@amidos.me>
 
 ENV DOCKER_VERSION=17.05.0-ce \
-    DOCKER_COMPOSE_VERSION=1.13.0 \
+    DOCKER_COMPOSE_VERSION=1.18.0 \
     ENTRYKIT_VERSION=0.4.0
 
 # Install Docker and Docker Compose


### PR DESCRIPTION
The new version supports vital `--abort-on-container-exit` flag for `docker-compose up`. Thanks to the flag, the docker-compose will go down as soon as one of the processes exists (for example a test suite finishes).