### PR TITLE
Fix "mount: can't find /sys/fs/cgroup in /proc/mounts" error in Concourse 5.0.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV DOCKER_VERSION=17.05.0-ce \
 
 # Install Docker and Docker Compose
 RUN apk --update --no-cache \
-    add curl device-mapper py-pip iptables && \
+    add curl util-linux device-mapper py-pip iptables && \
     rm -rf /var/cache/apk/* && \
     curl https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz | tar zx && \
     mv /docker/* /bin/ && chmod +x /bin/docker* && \


### PR DESCRIPTION
Install `util-linux` to fix `mount: can't find /sys/fs/cgroup in /proc/mounts` error in Concourse 5.0.0.

This fixed it for me. Based on https://github.com/concourse/docker-image-resource/commit/fd492346246e9e9f61040bf31c740e80fccc9365.
