### PR TITLE
update alpine, docker, docker-compose

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,18 @@
 # Inspired by https://github.com/mumoshu/dcind
-FROM alpine:3.7
+FROM alpine:3.10
 MAINTAINER Dmitry Matrosov <amidos@amidos.me>
 
-ENV DOCKER_VERSION=17.05.0-ce \
-    DOCKER_COMPOSE_VERSION=1.18.0 \
-    ENTRYKIT_VERSION=0.4.0
+ENV DOCKER_VERSION=18.09.7 \
+    DOCKER_COMPOSE_VERSION=1.23.2
 
 # Install Docker and Docker Compose
-RUN apk --update --no-cache \
-    add curl util-linux device-mapper py-pip iptables && \
-    rm -rf /var/cache/apk/* && \
-    curl https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz | tar zx && \
-    mv /docker/* /bin/ && chmod +x /bin/docker* && \
-    pip install docker-compose==${DOCKER_COMPOSE_VERSION}
-
-# Install entrykit
-RUN curl -L https://github.com/progrium/entrykit/releases/download/v${ENTRYKIT_VERSION}/entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz | tar zx && \
-    chmod +x entrykit && \
-    mv entrykit /bin/entrykit && \
-    entrykit --symlink
+RUN apk --update add curl util-linux device-mapper py-pip iptables \
+&& curl https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz | tar zx \
+&& mv /docker/* /bin/ \
+&& chmod +x /bin/docker* \
+&& pip install docker-compose==${DOCKER_COMPOSE_VERSION}
 
 # Include useful functions to start/stop docker daemon in garden-runc containers in Concourse CI.
 # Example: source /docker-lib.sh && start_docker
 COPY docker-lib.sh /docker-lib.sh
 
-ENTRYPOINT [ \
-	"switch", \
-		"shell=/bin/sh", "--", \
-	"codep", \
-		"/bin/docker daemon" \
-]


### PR DESCRIPTION
update alpine to latest stable of 3.10
update docker to latest stable community edition of 18.09.7
update docker-compose to latest of 1.24.1
rm entrykit: codep was not documented, and not using `start_docker` command
rm cache busting: can use `docker build --no-cache` for that