### PR TITLE
Upgrade Docker to 19.03.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,20 @@
 # Inspired by https://github.com/mumoshu/dcind
-FROM alpine:3.10
-LABEL maintainer="Dmitry Matrosov <amidos@amidos.me>"
+FROM alpine:3.20.1
 
-ENV DOCKER_VERSION=19.03.12 \
-    DOCKER_COMPOSE_VERSION=1.25.0
+ENV DOCKER_VERSION=25.0.3 \
+    DOCKER_COMPOSE_VERSION=2.28.1
 
-# Install Docker and Docker Compose
-RUN apk --no-cache add bash curl util-linux device-mapper py3-pip python3-dev libffi-dev openssl-dev gcc libc-dev make iptables && \
-    curl https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz | tar zx && \
+# Install Docker
+RUN apk --no-cache add bash curl util-linux device-mapper py3-pip python3-dev libffi-dev openssl-dev gcc libc-dev make iptables
+RUN curl https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz | tar zx && \
     mv /docker/* /bin/ && \
-    chmod +x /bin/docker* && \
-    pip3 install --upgrade pip && \
-    pip3 install docker-compose==${DOCKER_COMPOSE_VERSION} && \
-    rm -rf /root/.cache
+    chmod +x /bin/docker*
+# Install Docker Compose
+RUN mkdir -p ~/.docker/cli-plugins && \
+    curl -SL https://github.com/docker/compose/releases/download/v${DOCKER_COMPOSE_VERSION}/docker-compose-linux-x86_64 -o ~/.docker/cli-plugins/docker-compose && \
+    chmod +x ~/.docker/cli-plugins/docker-compose && \
+    echo -e '#!/bin/bash\nexec docker compose "$@"' > /usr/bin/docker-compose && \
+    chmod +x /usr/bin/docker-compose
 
 # Include functions to start/stop docker daemon
 COPY docker-lib.sh /docker-lib.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,12 @@ ENV DOCKER_VERSION=19.03.12 \
     DOCKER_COMPOSE_VERSION=1.25.0
 
 # Install Docker and Docker Compose
-RUN apk --no-cache add bash curl util-linux device-mapper py-pip python-dev libffi-dev openssl-dev gcc libc-dev make iptables && \
+RUN apk --no-cache add bash curl util-linux device-mapper py3-pip python3-dev libffi-dev openssl-dev gcc libc-dev make iptables && \
     curl https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz | tar zx && \
     mv /docker/* /bin/ && \
     chmod +x /bin/docker* && \
-    pip install docker-compose==${DOCKER_COMPOSE_VERSION} && \
+    pip3 install --upgrade pip && \
+    pip3 install docker-compose==${DOCKER_COMPOSE_VERSION} && \
     rm -rf /root/.cache
 
 # Include functions to start/stop docker daemon

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.10
 LABEL maintainer="Dmitry Matrosov <amidos@amidos.me>"
 
 ENV DOCKER_VERSION=19.03.12 \
-    DOCKER_COMPOSE_VERSION=1.24.1
+    DOCKER_COMPOSE_VERSION=1.25.0
 
 # Install Docker and Docker Compose
 RUN apk --no-cache add bash curl util-linux device-mapper py-pip python-dev libffi-dev openssl-dev gcc libc-dev make iptables && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 FROM alpine:3.10
 LABEL maintainer="Dmitry Matrosov <amidos@amidos.me>"
 
-ENV DOCKER_VERSION=18.09.8 \
+ENV DOCKER_VERSION=19.03.12 \
     DOCKER_COMPOSE_VERSION=1.24.1
 
 # Install Docker and Docker Compose

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -11,11 +11,17 @@ RUN apt-get update
 # from https://www.theserverside.com/blog/Coffee-Talk-Java-News-Stories-and-Opinions/How-to-install-Docker-and-docker-compose-on-Ubuntu#:~:text=Docker%20and%20compose%20install%20steps%20on%20Ubuntu&text=Download%20Docker%20GPG%20file,Docker%20and%20docker%20compose%20setup
 RUN apt-get -y install curl gnupg ca-certificates lsb-release git-all
 RUN mkdir -p /etc/apt/keyrings && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee -a /etc/apt/sources.list.d/docker.list > /dev/null
+# https://github.com/cli/cli/blob/trunk/docs/install_linux.md
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg 
+RUN chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee -a /etc/apt/sources.list.d/github-cli.list > /dev/null
+
 # must run it "update" again per: https://stackoverflow.com/questions/71393595/installing-docker-in-ubuntu-from-repo-cant-find-a-repo
 RUN apt-get update
+RUN apt-get -y install gh
 RUN apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
-USER runner
+#USER runner
 
 ENTRYPOINT ["/entrypoint.sh"]
 CMD ["/bin/bash"]

--- a/Dockerfile.ubuntu
+++ b/Dockerfile.ubuntu
@@ -1,0 +1,21 @@
+# Inspired by https://github.com/mumoshu/dcind
+# see : https://github.com/actions/runner-images/issues/7606
+FROM summerwind/actions-runner:ubuntu-22.04
+LABEL maintainer="Henry Chan <henry.chan@opendoor.com>"
+USER root
+ENV DOCKER_VERSION=19.03.12 \
+    DOCKER_COMPOSE_VERSION=1.25.0
+
+RUN apt-get update
+# Install Docker and Docker Compose
+# from https://www.theserverside.com/blog/Coffee-Talk-Java-News-Stories-and-Opinions/How-to-install-Docker-and-docker-compose-on-Ubuntu#:~:text=Docker%20and%20compose%20install%20steps%20on%20Ubuntu&text=Download%20Docker%20GPG%20file,Docker%20and%20docker%20compose%20setup
+RUN apt-get -y install curl gnupg ca-certificates lsb-release git-all
+RUN mkdir -p /etc/apt/keyrings && curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | tee /etc/apt/sources.list.d/docker.list > /dev/null
+# must run it "update" again per: https://stackoverflow.com/questions/71393595/installing-docker-in-ubuntu-from-repo-cant-find-a-repo
+RUN apt-get update
+RUN apt-get -y install docker-ce docker-ce-cli containerd.io docker-compose-plugin
+USER runner
+
+ENTRYPOINT ["/entrypoint.sh"]
+CMD ["/bin/bash"]

--- a/buildAndPushDockerhub.sh
+++ b/buildAndPushDockerhub.sh
@@ -5,8 +5,8 @@
 # we also need dcind to keep parity with Concourse
 export PUSH_FLAG="--push"
 export BUILD_FLAG="buildx build --platform linux/amd64"
-export TAG=2.0.0
-export IMAGE=opendoor/dcind-ubuntu
+export TAG=docker-25.0.3
+export IMAGE=opendoor/dcind
 if [ "$#" -gt 0 ]
 then
 	PUSH_FLAG=""
@@ -14,5 +14,5 @@ then
 	echo This is a local build for your Mac
 fi
 # docker login --username=$DOCKER_USERNAME --password=$DOCKER_PASSWORD
-docker $BUILD_FLAG -t $IMAGE:$TAG . $PUSH_FLAG -f Dockerfile.ubuntu
+docker $BUILD_FLAG -t $IMAGE:$TAG . $PUSH_FLAG -f Dockerfile
 echo Built $IMAGE:$TAG

--- a/buildAndPushDockerhub.sh
+++ b/buildAndPushDockerhub.sh
@@ -1,0 +1,18 @@
+# by Henry Chan
+# this file is built on Mac M1 (ARM) and pushed to Dockerhub (AMD64)
+# we are basing this off of Ubuntu because that's what GHA uses
+# https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md
+# we also need dcind to keep parity with Concourse
+export PUSH_FLAG="--push"
+export BUILD_FLAG="buildx build --platform linux/amd64"
+export TAG=2.0.0
+export IMAGE=opendoor/dcind-ubuntu
+if [ "$#" -gt 0 ]
+then
+	PUSH_FLAG=""
+	BUILD_FLAG="build"
+	echo This is a local build for your Mac
+fi
+# docker login --username=$DOCKER_USERNAME --password=$DOCKER_PASSWORD
+docker $BUILD_FLAG -t $IMAGE:$TAG . $PUSH_FLAG -f Dockerfile.ubuntu
+echo Built $IMAGE:$TAG

--- a/docker-lib.sh
+++ b/docker-lib.sh
@@ -3,7 +3,7 @@
 
 LOG_FILE=${LOG_FILE:-/tmp/docker.log}
 SKIP_PRIVILEGED=${SKIP_PRIVILEGED:-false}
-STARTUP_TIMEOUT=${STARTUP_TIMEOUT:-20}
+STARTUP_TIMEOUT=${STARTUP_TIMEOUT:-60}
 DOCKER_DATA_ROOT=${DOCKER_DATA_ROOT:-/scratch/docker}
 
 sanitize_cgroups() {
@@ -106,6 +106,10 @@ start_docker() {
 
     if ! timeout ${STARTUP_TIMEOUT} bash -ce 'while true; do try_start && break; done'; then
       echo Docker failed to start within ${STARTUP_TIMEOUT} seconds.
+      echo "Logs"
+      echo "------------------------------------------------------------------"
+      cat $LOG_FILE
+      echo "------------------------------------------------------------------"
       return 1
     fi
   else


### PR DESCRIPTION
This PR updates the version of Docker to `19.03.12`. In particular the latest versions of Docker use api version `1.40`, while the current version (`18.09.8`) uses api version `1.39` and updating should address versioning issues like https://github.com/kubernetes-sigs/kubespray/issues/6160.

I have built and used the image, and can confirm that the new version works as expected.