### PR TITLE
Output log file to console on docker_start failure

### DIFF
--- a/docker-lib.sh
+++ b/docker-lib.sh
@@ -105,6 +105,7 @@ start_docker() {
     declare -fx try_start
 
     if ! timeout ${STARTUP_TIMEOUT} bash -ce 'while true; do try_start && break; done'; then
+      cat "${LOG_FILE}"
       echo Docker failed to start within ${STARTUP_TIMEOUT} seconds.
       return 1
     fi


### PR DESCRIPTION
This PR outputs the contents of the log file to console in the event docker fails to start. A lot of my users are having issues with docker starting, and troubleshooting is difficult without this information. The containers have often been garbage collected by the time I come to investigate.

Signed-off-by: Tom Bartlett <tom.bartlett@spire.com>