### PR TITLE
fix: support cgroups v2 in sanitize_cgroups

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,76 @@
+name: Docker
+
+on:
+  push:
+    # Publish `master` as Docker `latest` image.
+    branches:
+      - master
+
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+
+  # Run tests for any PRs.
+  pull_request:
+
+env:
+  # TODO: Change variable to your image's name.
+  IMAGE_NAME: image
+
+jobs:
+  # Run tests.
+  # See also https://docs.docker.com/docker-hub/builds/automated-testing/
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run tests
+        run: |
+          if [ -f docker-compose.test.yml ]; then
+            docker-compose --file docker-compose.test.yml build
+            docker-compose --file docker-compose.test.yml run sut
+          else
+            docker build . --file Dockerfile
+          fi
+
+  # Push image to GitHub Packages.
+  # See also https://docs.docker.com/docker-hub/builds/
+  push:
+    # Ensure test job passes before pushing image.
+    needs: test
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build image
+        run: docker build . --file Dockerfile --tag $IMAGE_NAME
+
+      - name: Log into registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Strip "v" prefix from tag name
+          [[ "${{ github.ref }}" == "refs/tags/"* ]] && VERSION=$(echo $VERSION | sed -e 's/^v//')
+
+          # Use Docker `latest` tag convention
+          [ "$VERSION" == "master" ] && VERSION=latest
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,4 +1,4 @@
-name: Docker
+name: Build and publish docker container image for netresearch/dcind
 
 on:
   push:
@@ -14,7 +14,6 @@ on:
   pull_request:
 
 env:
-  # TODO: Change variable to your image's name.
   IMAGE_NAME: dcind
 
 jobs:
@@ -53,7 +52,7 @@ jobs:
       - name: Log into registry
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
-          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+          echo "${{ secrets.CR_PAT }}" | docker login https://ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push image
         run: |

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -51,14 +51,18 @@ jobs:
         run: docker build . --file Dockerfile --tag $IMAGE_NAME
 
       - name: Log into registry
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login docker.pkg.github.com -u ${{ github.actor }} --password-stdin
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 
       - name: Push image
         run: |
           IMAGE_ID=docker.pkg.github.com/${{ github.repository }}/$IMAGE_NAME
+          GHCR_IMAGE_ID=ghcr.io/netresearch/$IMAGE_NAME
 
           # Change all uppercase to lowercase
           IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+          GHCR_IMAGE_ID=$(echo $GHCR_IMAGE_ID | tr '[A-Z]' '[a-z]')
 
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
@@ -70,7 +74,10 @@ jobs:
           [ "$VERSION" == "master" ] && VERSION=latest
 
           echo IMAGE_ID=$IMAGE_ID
+          echo GHCR_IMAGE_ID=$GHCR_IMAGE_ID
           echo VERSION=$VERSION
 
           docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
           docker push $IMAGE_ID:$VERSION
+          docker tag $IMAGE_NAME $GHCR_IMAGE_ID:$VERSION
+          docker push $GHCR_IMAGE_ID:$VERSION

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -15,7 +15,7 @@ on:
 
 env:
   # TODO: Change variable to your image's name.
-  IMAGE_NAME: image
+  IMAGE_NAME: dcind
 
 jobs:
   # Run tests.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,10 @@
 # Inspired by https://github.com/mumoshu/dcind
-FROM alpine:3.7
+FROM docker:dind
 
 LABEL maintainer.1="André Hähnel <andre.haehnel@netresearch.de>" \
       maintainer.2="Sebastian Mendel <sebastian.mendel@netresearch.de>"
 
-ENV DOCKER_VERSION=17.05.0-ce \
-    DOCKER_COMPOSE_VERSION=1.19.0 \
+ENV DOCKER_COMPOSE_VERSION=1.19.0 \
     ENTRYKIT_VERSION=0.4.0
 
 # Install Docker and Docker Compose
@@ -19,8 +18,6 @@ RUN apk --update --no-cache add \
     py-pip \
     redis \
  && apk upgrade \
- && curl https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz | tar zx \
- && mv /docker/* /bin/ && chmod +x /bin/docker* \
  && pip install docker-compose==${DOCKER_COMPOSE_VERSION} \
  && pip install docker-squash \
 # Install entrykit
@@ -41,5 +38,5 @@ ENTRYPOINT [ \
 	"switch", \
 		"shell=/bin/sh", "--", \
 	"codep", \
-		"/bin/dockerd" \
+		"/usr/local/bin/dockerd" \
 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,5 +28,5 @@ ENTRYPOINT [ \
 	"switch", \
 		"shell=/bin/sh", "--", \
 	"codep", \
-		"/bin/docker daemon" \
+		"/bin/dockerd" \
 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,6 @@ RUN apk --update --no-cache add \
     redis \
  && apk upgrade \
  && pip install docker-compose==${DOCKER_COMPOSE_VERSION} \
- && pip install docker-squash \
 # Install entrykit
  && curl -L https://github.com/progrium/entrykit/releases/download/v${ENTRYKIT_VERSION}/entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz | tar zx \
  && chmod +x entrykit \

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,8 @@ RUN apk --update --no-cache add \
  && mv entrykit /bin/entrykit \
  && entrykit --symlink \
 # cleanup
- && rm -rf /var/cache/apk/*
+ && rm -rf /var/cache/apk/* \
+ && rm -rf /root/.cache
 
 
 # Include useful functions to start/stop docker daemon in garden-runc containers in Concourse CI.

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,15 +19,18 @@ RUN apk --update --no-cache add \
     py-pip \
     redis \
  && apk upgrade \
- && rm -rf /var/cache/apk/* \
  && curl https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz | tar zx \
  && mv /docker/* /bin/ && chmod +x /bin/docker* \
  && pip install docker-compose==${DOCKER_COMPOSE_VERSION} \
+ && pip install docker-squash \
 # Install entrykit
  && curl -L https://github.com/progrium/entrykit/releases/download/v${ENTRYKIT_VERSION}/entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz | tar zx \
  && chmod +x entrykit \
  && mv entrykit /bin/entrykit \
- && entrykit --symlink
+ && entrykit --symlink \
+# cleanup
+ && rm -rf /var/cache/apk/*
+
 
 # Include useful functions to start/stop docker daemon in garden-runc containers in Concourse CI.
 # Example: source /docker-lib.sh && start_docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM docker:dind
 LABEL maintainer.1="André Hähnel <andre.haehnel@netresearch.de>" \
       maintainer.2="Sebastian Mendel <sebastian.mendel@netresearch.de>"
 
-ENV DOCKER_COMPOSE_VERSION=1.19.0 \
+ENV DOCKER_COMPOSE_VERSION=1.21.0 \
     ENTRYKIT_VERSION=0.4.0
 
 # Install Docker and Docker Compose

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.7
 MAINTAINER Dmitry Matrosov <amidos@amidos.me>
 
 ENV DOCKER_VERSION=17.05.0-ce \
-    DOCKER_COMPOSE_VERSION=1.18.0 \
+    DOCKER_COMPOSE_VERSION=1.19.0 \
     ENTRYKIT_VERSION=0.4.0
 
 # Install Docker and Docker Compose

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,9 +33,11 @@ RUN apk --update --no-cache add \
 # Example: source /docker-lib.sh && start_docker
 COPY docker-lib.sh /docker-lib.sh
 
+COPY setup /
+
 ENTRYPOINT [ \
 	"switch", \
-		"shell=/bin/sh", "--", \
+		"shell=/bin/bash", "--", \
 	"codep", \
 		"/usr/local/bin/dockerd" \
 ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,33 @@
 # Inspired by https://github.com/mumoshu/dcind
 FROM alpine:3.7
-MAINTAINER Dmitry Matrosov <amidos@amidos.me>
+
+LABEL maintainer.1="André Hähnel <andre.haehnel@netresearch.de>" \
+      maintainer.2="Sebastian Mendel <sebastian.mendel@netresearch.de>"
 
 ENV DOCKER_VERSION=17.05.0-ce \
     DOCKER_COMPOSE_VERSION=1.19.0 \
     ENTRYKIT_VERSION=0.4.0
 
 # Install Docker and Docker Compose
-RUN apk --update --no-cache \
-    add curl device-mapper py-pip iptables bash coreutils make redis && \
-    apk upgrade && \
-    rm -rf /var/cache/apk/* && \
-    curl https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz | tar zx && \
-    mv /docker/* /bin/ && chmod +x /bin/docker* && \
-    pip install docker-compose==${DOCKER_COMPOSE_VERSION}
-
+RUN apk --update --no-cache add \
+    bash \
+    coreutils \
+    curl \
+    device-mapper \
+    iptables \
+    make \
+    py-pip \
+    redis \
+ && apk upgrade \
+ && rm -rf /var/cache/apk/* \
+ && curl https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz | tar zx \
+ && mv /docker/* /bin/ && chmod +x /bin/docker* \
+ && pip install docker-compose==${DOCKER_COMPOSE_VERSION} \
 # Install entrykit
-RUN curl -L https://github.com/progrium/entrykit/releases/download/v${ENTRYKIT_VERSION}/entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz | tar zx && \
-    chmod +x entrykit && \
-    mv entrykit /bin/entrykit && \
-    entrykit --symlink
+ && curl -L https://github.com/progrium/entrykit/releases/download/v${ENTRYKIT_VERSION}/entrykit_${ENTRYKIT_VERSION}_Linux_x86_64.tgz | tar zx \
+ && chmod +x entrykit \
+ && mv entrykit /bin/entrykit \
+ && entrykit --symlink
 
 # Include useful functions to start/stop docker daemon in garden-runc containers in Concourse CI.
 # Example: source /docker-lib.sh && start_docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ FROM docker:dind
 LABEL maintainer.1="André Hähnel <andre.haehnel@netresearch.de>" \
       maintainer.2="Sebastian Mendel <sebastian.mendel@netresearch.de>"
 
-ENV DOCKER_COMPOSE_VERSION=1.21.0 \
+ENV DOCKER_COMPOSE_VERSION=1.22.0 \
     ENTRYKIT_VERSION=0.4.0
 
 # Install Docker and Docker Compose

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ENV DOCKER_VERSION=17.05.0-ce \
 
 # Install Docker and Docker Compose
 RUN apk --update --no-cache \
-    add curl device-mapper py-pip iptables && \
+    add curl device-mapper py-pip iptables bash coreutils make redis && \
     rm -rf /var/cache/apk/* && \
     curl https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz | tar zx && \
     mv /docker/* /bin/ && chmod +x /bin/docker* && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV DOCKER_VERSION=17.05.0-ce \
 # Install Docker and Docker Compose
 RUN apk --update --no-cache \
     add curl device-mapper py-pip iptables bash coreutils make redis && \
+    apk upgrade && \
     rm -rf /var/cache/apk/* && \
     curl https://get.docker.com/builds/Linux/x86_64/docker-${DOCKER_VERSION}.tgz | tar zx && \
     mv /docker/* /bin/ && chmod +x /bin/docker* && \

--- a/README.md
+++ b/README.md
@@ -62,3 +62,22 @@ Here is an example of a Concourse [job](http://concourse.ci/concepts.html) that 
 
 
 ```
+
+## Included tools
+
+### Messages
+For better organized log files, this image provides commands on the CLI for a colourful output:
+
+```bash
+message info "Short info message"
+
+message header "Big headline with deviders"
+
+message error 418 "Error message with exit code"
+
+message warn "Use it when something goes wrong"
+
+message ok "Use it for successful processes"
+
+message code "<example>My exaple code</example>"
+```

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # dcind (Docker-Compose-in-Docker)
 
-[![](https://images.microbadger.com/badges/image/amidos/dcind.svg)](http://microbadger.com/images/amidos/dcind "Get your own image badge on microbadger.com")
+[![](https://images.microbadger.com/badges/image/netresearch/dcind.svg)](http://microbadger.com/images/netresearch/dcind "Get your own image badge on microbadger.com")
 
-Use this ```Dockerfile``` to build a base image for your integration tests in [Concourse CI](http://concourse.ci/). Alternatively, you can use a ready-to-use image from the Docker Hub: [amidos/dcind](https://hub.docker.com/r/amidos/dcind/). The image is Alpine based.
+Use this ```Dockerfile``` to build a base image for your integration tests in [Concourse CI](http://concourse.ci/). Alternatively, you can use a ready-to-use image from the Docker Hub: [netresearch/dcind](https://hub.docker.com/r/netresearch/dcind/). The image is Alpine based.
 
-Here is an example of a Concourse [job](http://concourse.ci/concepts.html) that uses ```amidos/dcind``` image to run a bunch of containers in a task, and then runs the integration test suite. You can find a full version of this example in the [```example```](example) directory.
+Here is an example of a Concourse [job](http://concourse.ci/concepts.html) that uses ```netresearch/dcind``` image to run a bunch of containers in a task, and then runs the integration test suite. You can find a full version of this example in the [```example```](example) directory.
 
 ```yaml
   - name: integration
@@ -25,7 +25,7 @@ Here is an example of a Concourse [job](http://concourse.ci/concepts.html) that 
           image_resource:
             type: docker-image
             source:
-              repository: amidos/dcind
+              repository: netresearch/dcind
           inputs:
             - name: code
             - name: redis

--- a/README.md
+++ b/README.md
@@ -49,15 +49,14 @@ Here is an example of a Concourse [job](http://concourse.ci/concepts.html) that 
                 docker load -i busybox/image
                 docker tag "$(cat busybox/image-id)" "$(cat busybox/repository):$(cat busybox/tag)"
 
-                # This is just to visually check in the log that images have been loaded successfully
+                message info This is just to visually check in the log that images have been loaded successfully
                 docker images
 
-                # Run the container with tests and its dependencies.
+                message Run the container with tests and its dependencies.
                 docker-compose -f code/example/integration.yml run tests
 
-                # Cleanup.
-                # Not sure if this is required.
-                # It's quite possible that Concourse is smart enough to clean up the Docker mess itself.
+                message header Cleanup.
+                message info Not sure if this is required. It's quite possible that Concourse is smart enough to clean up the Docker mess itself.
                 docker-compose -f code/example/integration.yml down
                 docker volume rm $(docker volume ls -q)
 

--- a/docker-lib.sh
+++ b/docker-lib.sh
@@ -14,7 +14,7 @@ sanitize_cgroups() {
       continue
     fi
 
-    grouping="$(cat /proc/self/cgroup | cut -d: -f2 | grep "\\<$sys\\>")"
+    grouping="$(cat /proc/self/cgroup | cut -d: -f2 | grep "\\<$sys\\>")" || true
     if [ -z "$grouping" ]; then
       # subsystem not mounted anywhere; mount it on its own
       grouping="$sys"

--- a/docker-lib.sh
+++ b/docker-lib.sh
@@ -39,6 +39,11 @@ sanitize_cgroups() {
       ln -s "$mountpoint" "/sys/fs/cgroup/$sys"
     fi
   done
+
+  if ! test -e /sys/fs/cgroup/systemd ; then
+    mkdir /sys/fs/cgroup/systemd
+    mount -t cgroup -o none,name=systemd none /sys/fs/cgroup/systemd
+  fi
 }
 
 start_docker() {

--- a/docker-lib.sh
+++ b/docker-lib.sh
@@ -58,7 +58,13 @@ start_docker() {
   local server_args="--mtu ${mtu}"
   local registry=""
 
-  server_args="${server_args} --max-concurrent-downloads=$1 --max-concurrent-uploads=$2"
+  if [ -n "$1" ]; then
+    server_args="${server_args} --max-concurrent-downloads=$1"
+  fi
+
+  if [ -n "$2" ]; then
+    server_args="${server_args} --max-concurrent-uploads=$2"
+  fi
 
   for registry in $3; do
     server_args="${server_args} --insecure-registry ${registry}"

--- a/docker-lib.sh
+++ b/docker-lib.sh
@@ -51,7 +51,9 @@ start_docker() {
     mount -o remount,rw /proc/sys
   fi
 
-  local server_args=""
+  local mtu=$(cat /sys/class/net/$(ip route get 8.8.8.8|awk '{ print $5 }')/mtu)
+  local server_args="--mtu ${mtu}"
+  local registry=""
 
   for registry in $1; do
     server_args="${server_args} --insecure-registry ${registry}"
@@ -61,11 +63,8 @@ start_docker() {
     server_args="${server_args} --registry-mirror=$2"
   fi
 
-  if [ -n "$3" ]; then
-    server_args="${server_args} -g=$3"
-  fi
 
-  docker daemon --data-root /scratch/docker ${server_args} >/tmp/docker.log 2>&1 &
+  dockerd --data-root /scratch/docker ${server_args} >/tmp/docker.log 2>&1 &
   echo $! > /tmp/docker.pid
 
   trap stop_docker EXIT

--- a/docker-lib.sh
+++ b/docker-lib.sh
@@ -63,7 +63,7 @@ start_docker() {
     server_args="${server_args} --registry-mirror=$2"
   fi
 
-  server_args="${server_args} --experimental=true"
+  server_args="${server_args} --experimental"
 
   dockerd --data-root /scratch/docker ${server_args} >/tmp/docker.log 2>&1 &
   echo $! > /tmp/docker.pid

--- a/docker-lib.sh
+++ b/docker-lib.sh
@@ -84,6 +84,5 @@ stop_docker() {
     return 0
   fi
 
-  kill -TERM $pid
-  wait $pid
+  kill $pid
 }

--- a/docker-lib.sh
+++ b/docker-lib.sh
@@ -63,6 +63,7 @@ start_docker() {
     server_args="${server_args} --registry-mirror=$2"
   fi
 
+  server_args="${server_args} --experimental=true"
 
   dockerd --data-root /scratch/docker ${server_args} >/tmp/docker.log 2>&1 &
   echo $! > /tmp/docker.pid

--- a/docker-lib.sh
+++ b/docker-lib.sh
@@ -1,4 +1,5 @@
-# Ref: https://github.com/concourse/docker-image-resource/blob/master/assets/common.sh
+LOG_FILE=${LOG_FILE:-/tmp/docker.log}
+SKIP_PRIVILEGED=${SKIP_PRIVILEGED:-false}
 
 sanitize_cgroups() {
   mkdir -p /sys/fs/cgroup
@@ -44,28 +45,30 @@ start_docker() {
   mkdir -p /var/log
   mkdir -p /var/run
 
-  sanitize_cgroups
+  if [ "$SKIP_PRIVILEGED" = "false" ]; then
+    sanitize_cgroups
 
-  # check for /proc/sys being mounted readonly, as systemd does
-  if grep '/proc/sys\s\+\w\+\s\+ro,' /proc/mounts >/dev/null; then
-    mount -o remount,rw /proc/sys
+    # check for /proc/sys being mounted readonly, as systemd does
+    if grep '/proc/sys\s\+\w\+\s\+ro,' /proc/mounts >/dev/null; then
+      mount -o remount,rw /proc/sys
+    fi
   fi
 
   local mtu=$(cat /sys/class/net/$(ip route get 8.8.8.8|awk '{ print $5 }')/mtu)
   local server_args="--mtu ${mtu}"
   local registry=""
 
-  for registry in $1; do
+  server_args="${server_args} --max-concurrent-downloads=$1 --max-concurrent-uploads=$2"
+
+  for registry in $3; do
     server_args="${server_args} --insecure-registry ${registry}"
   done
 
-  if [ -n "$2" ]; then
-    server_args="${server_args} --registry-mirror=$2"
+  if [ -n "$4" ]; then
+    server_args="${server_args} --registry-mirror $4"
   fi
 
-  server_args="${server_args} --experimental"
-
-  dockerd --data-root /scratch/docker ${server_args} >/tmp/docker.log 2>&1 &
+  dockerd --data-root /scratch/docker ${server_args} >$LOG_FILE 2>&1 &
   echo $! > /tmp/docker.pid
 
   trap stop_docker EXIT
@@ -84,5 +87,106 @@ stop_docker() {
     return 0
   fi
 
-  kill $pid
+  kill -TERM $pid
+}
+
+log_in() {
+  local username="$1"
+  local password="$2"
+  local registry="$3"
+
+  if [ -n "${username}" ] && [ -n "${password}" ]; then
+    docker login -u "${username}" -p "${password}" ${registry}
+  else
+    mkdir -p ~/.docker
+    echo '{"credsStore":"ecr-login"}' >> ~/.docker/config.json
+  fi
+}
+
+private_registry() {
+  local repository="${1}"
+
+  if echo "${repository}" | fgrep -q '/' ; then
+    local registry="$(extract_registry "${repository}")"
+    if echo "${registry}" | fgrep -q '.' ; then
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+extract_registry() {
+  local repository="${1}"
+
+  echo "${repository}" | cut -d/ -f1
+}
+
+extract_repository() {
+  local long_repository="${1}"
+
+  echo "${long_repository}" | cut -d/ -f2-
+}
+
+image_from_tag() {
+  docker images --no-trunc "$1" | awk "{if (\$2 == \"$2\") print \$3}"
+}
+
+image_from_digest() {
+  docker images --no-trunc --digests "$1" | awk "{if (\$3 == \"$2\") print \$4}"
+}
+
+certs_to_file() {
+  local raw_ca_certs="${1}"
+  local cert_count="$(echo $raw_ca_certs | jq -r '. | length')"
+
+  for i in $(seq 0 $(expr "$cert_count" - 1));
+  do
+    local cert_dir="/etc/docker/certs.d/$(echo $raw_ca_certs | jq -r .[$i].domain)"
+    mkdir -p "$cert_dir"
+    echo $raw_ca_certs | jq -r .[$i].cert >> "${cert_dir}/ca.crt"
+  done
+}
+
+set_client_certs() {
+  local raw_client_certs="${1}"
+  local cert_count="$(echo $raw_client_certs | jq -r '. | length')"
+
+  for i in $(seq 0 $(expr "$cert_count" - 1));
+  do
+    local cert_dir="/etc/docker/certs.d/$(echo $raw_client_certs | jq -r .[$i].domain)"
+    [ -d "$cert_dir" ] || mkdir -p "$cert_dir"
+    echo $raw_client_certs | jq -r .[$i].cert >> "${cert_dir}/client.cert"
+    echo $raw_client_certs | jq -r .[$i].key >> "${cert_dir}/client.key"
+  done
+}
+
+docker_pull() {
+  GREEN='\033[0;32m'
+  RED='\033[0;31m'
+  NC='\033[0m' # No Color
+
+  pull_attempt=1
+  max_attempts=3
+  while [ "$pull_attempt" -le "$max_attempts" ]; do
+    printf "Pulling ${GREEN}%s${NC}" "$1"
+
+    if [ "$pull_attempt" != "1" ]; then
+      printf " (attempt %s of %s)" "$pull_attempt" "$max_attempts"
+    fi
+
+    printf "...\n"
+
+    if docker pull "$1"; then
+      printf "\nSuccessfully pulled ${GREEN}%s${NC}.\n\n" "$1"
+      return
+    fi
+
+    echo
+
+    pull_attempt=$(expr "$pull_attempt" + 1)
+  done
+
+  printf "\n${RED}Failed to pull image %s.${NC}" "$1"
+  exit 1
 }

--- a/docker-lib.sh
+++ b/docker-lib.sh
@@ -60,7 +60,7 @@ start_docker() {
   fi
 
   local mtu=$(cat /sys/class/net/$(ip route get 8.8.8.8|awk '{ print $5 }')/mtu)
-  local server_args="--mtu ${mtu}"
+  local server_args="--mtu ${mtu} --experimental"
   local registry=""
 
   if [ -n "$1" ]; then

--- a/example/pipe.yml
+++ b/example/pipe.yml
@@ -56,7 +56,7 @@ jobs:
           image_resource:
             type: docker-image
             source:
-              repository: amidos/dcind
+              repository: netresearch/dcind
           inputs:
             - name: code
             - name: redis

--- a/setup/usr/local/bin/message
+++ b/setup/usr/local/bin/message
@@ -31,7 +31,7 @@ function message() {
 }
 
 function messageError {
-    message "${red}erro${norm}" "${@:2}"
+    message "${red}erro${norm}" "${*}"
     exit $1
 }
 

--- a/setup/usr/local/bin/message
+++ b/setup/usr/local/bin/message
@@ -32,8 +32,7 @@ function message() {
 
 function messageError {
     message "${red}erro${norm}" "${@:2}"
-    spinner_stop $?
-	exit $1
+    exit $1
 }
 
 function messageWarn {
@@ -54,7 +53,7 @@ function messageCode {
 
 function messageHeader {
     echo -e "\n${blue}-----------------------------------------------------------------------------------------------------------${norm}"
-	echo -e "::::\t$*"
+    echo -e "::::\t$*"
     echo -e "${blue}-----------------------------------------------------------------------------------------------------------${norm}\n"
 }
 

--- a/setup/usr/local/bin/message
+++ b/setup/usr/local/bin/message
@@ -1,5 +1,13 @@
 #!/usr/bin/env bash
 
+# Messages
+#
+# @examples
+# message header My Headline
+# message info Just a small hint
+# message warn Something is wrong
+
+
 # Colour definitions
 red='\033[01;31m'
 blue='\033[0;34m'

--- a/setup/usr/local/bin/message
+++ b/setup/usr/local/bin/message
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+# Colour definitions
+red='\033[01;31m'
+blue='\033[0;34m'
+green='\033[01;32m'
+yellow='\033[0;33m'
+orange='\033[38;5;;172m'
+norm='\033[0m'
+code='\033[40m'
+
+# Styling definitions
+bold_begin='\033[1m'
+bold_end='\033[21m'
+underline_begin='\033[34;4m'
+underline_end='\033[24m'
+blink_begin='\033[33;5m'
+blink_end='\033[0m'
+
+# Message
+function message() {
+    echo -e "\r[${1}]\t\t${2}"
+}
+
+function messageError {
+    message "${red}erro${norm}" "${@:2}"
+    spinner_stop $?
+	exit $1
+}
+
+function messageWarn {
+	message "${yellow}warn${norm}" "$*"
+}
+
+function messageOk {
+	message "${green} ok ${norm}" "$*"
+}
+
+function messageInfo {
+	message "${blue}info${norm}" "$*"
+}
+
+function messageCode {
+	message "${yellow}code${norm}" "${code}$*${norm}"
+}
+
+function messageHeader {
+    echo -e "\n${blue}-----------------------------------------------------------------------------------------------------------${norm}"
+	echo -e "::::\t$*"
+    echo -e "${blue}-----------------------------------------------------------------------------------------------------------${norm}\n"
+}
+
+space=`df -h | awk '{print $5}' | grep % | grep -v Use | sort -n | tail -1 | cut -d "%" -f1 -`
+
+case $1 in
+header)
+  messageHeader $2
+  ;;
+code)
+  messageCode $2
+  ;;
+info)
+  messageInfo $2
+  ;;
+ok)
+  messageOk $2
+  ;;
+error)
+  messageError $2 $3
+  ;;
+warn)
+  messageWarn $2
+  ;;
+*)
+  messageInfo $1
+esac


### PR DESCRIPTION
## Summary

- skip v1 per-subsystem cgroup mounts when running on a cgroups v2 host
- modern dockerd handles the unified cgroup2 hierarchy natively

## Problem

on hosts with cgroups v2 (Debian 13, Ubuntu 24.04+, any kernel with `systemd.unified_cgroup_hierarchy=1`), `sanitize_cgroups()` fails with:

```
mount: mounting cgroup on /sys/fs/cgroup/cpuset failed: Resource busy
```

the function tries to mount individual cgroups v1 subsystems (`cpuset`, `memory`, etc.) under `/sys/fs/cgroup/$sys`, but on cgroups v2 the unified hierarchy is already mounted at `/sys/fs/cgroup/` as `cgroup2fs`.

## Fix

detect cgroups v2 via `/sys/fs/cgroup/cgroup.controllers` (only exists on v2) and return early. the v1 mount logic is preserved for older hosts.

## Related

- https://github.com/concourse/concourse/issues/8675
- https://github.com/concourse/oci-build-task/issues/138
- https://github.com/concourse/concourse/issues/9063